### PR TITLE
Time based tlm logging

### DIFF
--- a/fsw/src/ds_file.c
+++ b/fsw/src/ds_file.c
@@ -657,6 +657,8 @@ void DS_FileCreateSequence(char *Buffer, uint32 Type, uint32 Count)
 
         /*
         ** DS time string has format: "YYYYDDDHHMMSS"...
+
+        CONSIDER: TO ONLY KEEP 1 DIGIT OF YEAR (TRAILING DIGIT i.e., YDDDHHMMSS)
         */
         #define DS_YYYY_INDEX  0
         #define DS_DDD_INDEX   4

--- a/fsw/src/ds_file.c
+++ b/fsw/src/ds_file.c
@@ -657,8 +657,6 @@ void DS_FileCreateSequence(char *Buffer, uint32 Type, uint32 Count)
 
         /*
         ** DS time string has format: "YYYYDDDHHMMSS"...
-
-        CONSIDER: TO ONLY KEEP 1 DIGIT OF YEAR (TRAILING DIGIT i.e., YDDDHHMMSS)
         */
         #define DS_YYYY_INDEX  0
         #define DS_DDD_INDEX   4

--- a/fsw/src/ds_file.c
+++ b/fsw/src/ds_file.c
@@ -379,17 +379,21 @@ void DS_FileCreateDest(uint32 FileIndex)
     if (FileStatus->FileName[0] != DS_STRING_TERMINATOR)
     {
 
-        char* log_dir_path = dirname(strdup(FileStatus->FileName));
+        char log_dir_path[DS_TOTAL_FNAME_BUFSIZE];
+        char file_name_copy[DS_TOTAL_FNAME_BUFSIZE];
+        strncpy(file_name_copy, FileStatus->FileName, DS_TOTAL_FNAME_BUFSIZE-1);
+        file_name_copy[DS_TOTAL_FNAME_BUFSIZE-1]=DS_STRING_TERMINATOR;
+        strncpy(log_dir_path, dirname(file_name_copy), DS_TOTAL_FNAME_BUFSIZE-1);
+        log_dir_path[DS_TOTAL_FNAME_BUFSIZE-1]=DS_STRING_TERMINATOR;
         printf("LDP : %s \n", log_dir_path);
 
         /// We need to create the logging base directory if it doesn't exist
         struct stat st = {0};
 
-         if (stat(log_dir_path, &st) == -1) {
+        if (stat(log_dir_path, &st) == -1) {
 
-            char* target_dir = malloc(strlen(log_dir_path+1));
-            strcpy(target_dir, log_dir_path);
-            prepend(target_dir, ".");
+            char target_dir[DS_TOTAL_FNAME_BUFSIZE];
+            snprintf(target_dir, DS_TOTAL_FNAME_BUFSIZE, ".%s", log_dir_path);
             mkdir(target_dir, 0700);
             CFE_EVS_SendEvent(DS_CREATE_FILE_ERR_EID, CFE_EVS_EventType_ERROR,
                              ": msgpath='%s' dirname='%s'", FileStatus->FileName, target_dir);

--- a/fsw/tables/ds_file_tbl.c
+++ b/fsw/tables/ds_file_tbl.c
@@ -298,7 +298,7 @@ DS_DestFileTable_t DS_DestFileTable =
       /* .Basename      = */ "debug",
       /* .Extension     = */ "tlm",
 
-      /* .FileNameType  = */ DS_BY_COUNT,
+      /* .FileNameType  = */ DS_BY_TIME,
       /* .EnableState   = */ DS_ENABLED,
       /* .MaxFileSize   = */ (1024 * 1024 * 2),         /* 2 M-bytes */
       /* .MaxFileAge    = */ (60 * 60 * 2),             /* 2 hours */
@@ -313,7 +313,7 @@ DS_DestFileTable_t DS_DestFileTable =
       /* .Basename      = */ "nominal",
       /* .Extension     = */ "tlm",
 
-      /* .FileNameType  = */ DS_BY_COUNT,
+      /* .FileNameType  = */ DS_BY_TIME,
       /* .EnableState   = */ DS_ENABLED,
       /* .MaxFileSize   = */ (1024 * 1024 * 2),         /* 2 M-bytes */
       /* .MaxFileAge    = */ (60 * 60 * 2),             /* 2 hours */

--- a/fsw/tables/ds_file_tbl.c
+++ b/fsw/tables/ds_file_tbl.c
@@ -298,7 +298,7 @@ DS_DestFileTable_t DS_DestFileTable =
       /* .Basename      = */ "debug",
       /* .Extension     = */ "tlm",
 
-      /* .FileNameType  = */ DS_BY_TIME,
+      /* .FileNameType  = */ DS_BY_COUNT,
       /* .EnableState   = */ DS_ENABLED,
       /* .MaxFileSize   = */ (1024 * 1024 * 2),         /* 2 M-bytes */
       /* .MaxFileAge    = */ (60 * 60 * 2),             /* 2 hours */
@@ -313,7 +313,7 @@ DS_DestFileTable_t DS_DestFileTable =
       /* .Basename      = */ "nominal",
       /* .Extension     = */ "tlm",
 
-      /* .FileNameType  = */ DS_BY_TIME,
+      /* .FileNameType  = */ DS_BY_COUNT,
       /* .EnableState   = */ DS_ENABLED,
       /* .MaxFileSize   = */ (1024 * 1024 * 2),         /* 2 M-bytes */
       /* .MaxFileAge    = */ (60 * 60 * 2),             /* 2 hours */


### PR DESCRIPTION
1. Corrected memory allocation bug (now uses stack-allocated strings instead of heap-allocated strings in ds_file.c)
2. Changed file saving/writing nomenclature from DS_BY_COUNT to DS_BY_TIME (in ds_file_tbl.c) to save files by time (this is done from 12th January 1980, as that is what the time sync is at) (NOTE: a new file is still created every 2MB, which is ~every 4-5 minutes)
3. (NOTE: The DS App will still have to be re-enabled)